### PR TITLE
ICU: Fix that ICUCardData.balance is not set

### DIFF
--- a/TRETJapanNFCReader/FeliCa/FCFCampus/ICU/ICUCardData.swift
+++ b/TRETJapanNFCReader/FeliCa/FCFCampus/ICU/ICUCardData.swift
@@ -66,6 +66,7 @@ public struct ICUCardData: FeliCaCardData {
             return
         }
         self.transactions = blockData.map { toTransaction(data:$0) }
+        self.balance = self.transactions.first!.balance
     }
 
     private mutating func toTransaction(data: Data) -> ICUCardTransaction {


### PR DESCRIPTION
There is an issue that `ICUCardData.balance` is not set nevertheless tx was obtained.