### PR TITLE
Automatic document generation with SwiftDocOrg/swift-doc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Generate Documentation
         uses: SwiftDocOrg/swift-doc@master
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,6 +14,7 @@ jobs:
           inputs: "Sources"
           module-name: TRETNFCKit
           output: "documentation_md"
+          format: "commonmark"
       - name: Upload documentation to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:
@@ -26,6 +27,7 @@ jobs:
           inputs: "Sources"
           module-name: TRETNFCKit
           output: "documentation_html"
+          format: "html"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,9 +21,7 @@ jobs:
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          target_branch: gh-pages
-          build_dir: Documentation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./Documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,3 +40,10 @@ jobs:
           path: "documentation"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./documentation
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,12 +34,6 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-      - name: Upload documentation to GitHub Pages
-        uses: treastrain/github-pages-publish-action@v1
-        with:
-          path: "documentation"
-        env:
-          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,20 +8,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Generate Documentation
+      - name: Generate documentation for Wiki
         uses: SwiftDocOrg/swift-doc@master
         with:
           inputs: "Sources"
           module-name: TRETNFCKit
-          output: "Documentation"
-      - name: Upload Documentation to Wiki
+          output: "documentation_md"
+      - name: Upload documentation to Wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:
-          path: "Documentation"
+          path: "documentation_md"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Generate documentation for GitHub Pages
+        uses: SwiftDocOrg/swift-doc@master
+        with:
+          inputs: "Sources"
+          module-name: TRETNFCKit
+          output: "documentation_html"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./Documentation
+          publish_dir: ./documentation_html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,6 +34,9 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
+      - name: Copy documentation files from container
+        run: |
+          docker ps
       - name: Archive documentation (html) artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-          base-url: "/$GITHUB_REPOSITORY/documentation/"
+          base-url: "/${{ GITHUB_REPOSITORY }}/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,15 +40,3 @@ jobs:
           path: "documentation"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-#       - name: Archive documentation (html) artifacts
-#         uses: actions/upload-artifact@v2
-#         with:
-#           name: documentation (html)
-#           path: documentation
-#       - name: Deploy to GitHub Pages
-#         uses: peaceiris/actions-gh-pages@v3
-#         with:
-#           github_token: ${{ secrets.GITHUB_TOKEN }}
-#           publish_dir: ./documentation
-#           user_name: 'github-actions[bot]'
-#           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: echo ::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")
+      - run: echo "$REPOSITORY_NAME"
       - name: Generate documentation for GitHub Pages
         uses: SwiftDocOrg/swift-doc@master
         with:
@@ -34,7 +36,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-          base-url: "/TRETJapanNFCReader/documentation/"
+          base-url: "/${{ REPOSITORY_NAME }}/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,19 +34,9 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-      - name: Copy
-        run: |
-          mkdir tmp
-          cp -r documentation tmp
-      - name: Upload GitHub Pages archives
-        uses: actions/upload-artifact@v2
+      - name: Upload documentation to GitHub Pages
+        uses: treastrain/github-pages-publish-action@v1
         with:
-          name: documentation_gh-pages
-          path: tmp
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./tmp
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          path: "documentation"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: echo ::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")
-      - run: echo "$REPOSITORY_NAME"
       - name: Generate documentation for GitHub Pages
         uses: SwiftDocOrg/swift-doc@master
         with:
@@ -36,7 +34,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-          base-url: "/${{ REPOSITORY_NAME }}/documentation/"
+          base-url: "/${{ github.repository.name }}/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,18 +34,21 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-      - name: Copy documentation files from container
-        run: |
-          docker ps
-      - name: Archive documentation (html) artifacts
-        uses: actions/upload-artifact@v2
+      - name: Upload documentation to GitHub Pages
+        uses: treastrain/github-pages-publish-action@v1
         with:
-          name: documentation (html)
-          path: documentation
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documentation
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          path: "documentation"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+#       - name: Archive documentation (html) artifacts
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: documentation (html)
+#           path: documentation
+#       - name: Deploy to GitHub Pages
+#         uses: peaceiris/actions-gh-pages@v3
+#         with:
+#           github_token: ${{ secrets.GITHUB_TOKEN }}
+#           publish_dir: ./documentation
+#           user_name: 'github-actions[bot]'
+#           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           publish_dir: ./documentation_html
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,15 +34,19 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
+      - name: Copy
+        run: |
+          mkdir tmp
+          cp -r documentation tmp
       - name: Upload GitHub Pages archives
         uses: actions/upload-artifact@v2
         with:
           name: documentation_gh-pages
-          path: documentation
+          path: tmp
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documentation
+          publish_dir: ./tmp
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,22 @@
+name: Documentation
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate Documentation
+        uses: SwiftDocOrg/swift-doc@master
+        with:
+          inputs: "Sources"
+          module-name: TRETNFCKit
+          output: "Documentation"
+      - name: Upload Documentation to Wiki
+        uses: SwiftDocOrg/github-wiki-publish-action@v1
+        with:
+          path: "Documentation"
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-          base-url: "/${{ github.repository.name }}/documentation/"
+          base-url: "/${{ github.event.repository.name }}/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,38 +3,51 @@ name: Documentation
 on: [push]
 
 jobs:
-  build:
+  for_wiki:
+    name: Update wiki
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - name: Generate documentation for Wiki
+      - name: Generate documentation for wiki
         uses: SwiftDocOrg/swift-doc@master
         with:
           inputs: "Sources"
           module-name: TRETNFCKit
-          output: "documentation_md"
+          output: "documentation"
           format: "commonmark"
-      - name: Upload documentation to Wiki
+      - name: Upload wiki archives
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation_wiki
+          path: documentation
+      - name: Upload documentation to wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:
-          path: "documentation_md"
+          path: "documentation"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  for_pages:
+    name: Update GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Generate documentation for GitHub Pages
         uses: SwiftDocOrg/swift-doc@master
         with:
           inputs: "Sources"
           module-name: TRETNFCKit
-          output: "documentation_html"
+          output: "documentation"
           format: "html"
-      - name: ls
-        run: ls -a; ls -a ./documentation_html
+      - name: Upload GitHub Pages archives
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation_gh-pages
+          path: documentation
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./documentation_html
+          publish_dir: ./documentation
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,6 +34,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
+          base-url: "/$GITHUB_REPOSITORY/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,11 +15,6 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "commonmark"
-      - name: Upload wiki archives
-        uses: actions/upload-artifact@v2
-        with:
-          name: documentation_wiki
-          path: documentation
       - name: Upload documentation to wiki
         uses: SwiftDocOrg/github-wiki-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,8 @@
 name: Documentation
 
-on: [push]
+on:
+  # push:
+  pull_request:
 
 jobs:
   for_wiki:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
-          base-url: "/${{ GITHUB_REPOSITORY }}/documentation/"
+          base-url: "/TRETJapanNFCReader/documentation/"
       - name: Upload documentation to GitHub Pages
         uses: treastrain/github-pages-publish-action@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,10 +28,12 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation_html"
           format: "html"
+      - name: ls
+        run: ls -a; ls -a ./documentation_html
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./documentation_html
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,6 +34,11 @@ jobs:
           module-name: TRETNFCKit
           output: "documentation"
           format: "html"
+      - name: Archive documentation (html) artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation (html)
+          path: documentation
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,3 +20,10 @@ jobs:
           path: "Documentation"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      - name: Deploy to GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: Documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Close #49 

[SwiftDocOrg/swift-doc](https://github.com/SwiftDocOrg/swift-doc) generates the documentation automatically.
There are two places to publish it: [the Wiki in this repository](../wiki), and GitHub Pages.