### PR TITLE
Support Swift Concurrency back-deploy

### DIFF
--- a/Sources/NFCKit/NFCKitNDEFReaderSession/NFCKitNDEFReaderSession.swift
+++ b/Sources/NFCKit/NFCKitNDEFReaderSession/NFCKitNDEFReaderSession.swift
@@ -30,7 +30,23 @@ extension CoreNFC.NFCNDEFReaderSession {
         })
     }
     
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /// Connects the reader session to a tag and activates that tag.
+    ///
+    /// A tag stays connected until your app connects to a different tag or restarts polling. Connecting to a tag that is already connected has no effect.
+    /// - Parameter tag: A tag to which the reader session should attempt to connect.
+    /// - Returns: A Result with the cases:
+    ///              success: A `Void`.
+    ///              failure: An `NFCReaderError` object indicating that a communication issue with the tag occurred.
+    open func connect(to tag: NFCNDEFTag) async -> Result<Void, NFCReaderError> {
+        do {
+            let _: Void = try await connect(to: tag)
+            return .success(())
+        } catch {
+            return .failure(error as! NFCReaderError)
+        }
+    }
+    #elseif compiler(>=5.5) && canImport(_Concurrency)
     /// Connects the reader session to a tag and activates that tag.
     ///
     /// A tag stays connected until your app connects to a different tag or restarts polling. Connecting to a tag that is already connected has no effect.

--- a/Sources/NFCKit/NFCKitTagReaderSession/NFCKitTagReaderSession.swift
+++ b/Sources/NFCKit/NFCKitTagReaderSession/NFCKitTagReaderSession.swift
@@ -30,7 +30,32 @@ extension CoreNFC.NFCTagReaderSession {
         })
     }
     
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if compiler(>=5.5.2) && canImport(_Concurrency)
+    /// Connects the reader session to a tag and activates that tag.
+    ///
+    /// A tag stays connected until your app connects to a different tag or restarts polling. Connecting to a tag that is already connected has no effect.
+    /// - Parameter tag: A tag to which the reader session should attempt to connect.
+    /// - Returns: A Result with the cases:
+    ///              success: A `Void`.
+    ///              failure: An `NFCReaderError` object indicating that a communication issue with the tag occurred.
+    @available(iOS 13.0, *)
+    open func connect(to tag: NFCTag) async -> Result<Void, NFCReaderError> {
+        if #available(iOS 15.0, *) {
+            do {
+                let _: Void = try await connect(to: tag)
+                return .success(())
+            } catch {
+                return .failure(error as! NFCReaderError)
+            }
+        } else {
+            return await withCheckedContinuation { continuation in
+                connect(to: tag) { result in
+                    continuation.resume(returning: result)
+                }
+            }
+        }
+    }
+    #elseif compiler(>=5.5) && canImport(_Concurrency)
     /// Connects the reader session to a tag and activates that tag.
     ///
     /// A tag stays connected until your app connects to a different tag or restarts polling. Connecting to a tag that is already connected has no effect.


### PR DESCRIPTION
Support Swift Concurrency
- Xcode 13.0 - 13.1　iOS 15.0+
- Xcode 13.2 beta 　iOS 13.0+ (back-deploy)