### PR TITLE
`NFCReaderSessionAfterBeginProtocol.restartPolling()` を unavailable にする

### DIFF
--- a/Sources/Core/NFCReaderSessionAfterBeginProtocol.swift
+++ b/Sources/Core/NFCReaderSessionAfterBeginProtocol.swift
@@ -13,3 +13,8 @@ public protocol NFCReaderSessionAfterBeginProtocol: NSObjectProtocol, Sendable {
     func invalidate(errorMessage: String)
     #endif
 }
+
+extension NFCReaderSessionAfterBeginProtocol {
+    @available(*, unavailable, message: "Use `DetectResult.restartPolling`")
+    public func restartPolling() {}
+}


### PR DESCRIPTION
close #111