### PR TITLE
存在型に `any` を付ける

### DIFF
--- a/Sources/NDEFTag/NDEFTag.swift
+++ b/Sources/NDEFTag/NDEFTag.swift
@@ -9,7 +9,7 @@ public enum NDEFTag: NFCTagType {
     #if canImport(CoreNFC)
     public typealias ReaderSession = NFCNDEFReaderSession
     public typealias ReaderSessionProtocol = _NDEFTagOpaqueTypeBuilder.ReaderSessionProtocol // it means like `some NFCNDEFTagReaderSessionProtocol`
-    public typealias ReaderSessionDetectObject = [NFCNDEFTag]
+    public typealias ReaderSessionDetectObject = [any NFCNDEFTag]
     #endif
 }
 

--- a/Sources/NDEFTag/NFCNDEFTagReaderSessionCallbackHandleObject.swift
+++ b/Sources/NDEFTag/NFCNDEFTagReaderSessionCallbackHandleObject.swift
@@ -55,7 +55,7 @@ extension NFCNDEFTagReaderSessionCallbackHandleObject: NDEFTag.ReaderSession.Del
 }
 
 extension NFCNDEFTagReaderSessionCallbackHandleObject {
-    func didDetect(session: NFCNDEFReaderSession, tags: [NFCNDEFTag]) async {
+    func didDetect(session: NFCNDEFReaderSession, tags: [any NFCNDEFTag]) async {
         let result: TagType.DetectResult
         do {
             result = try await didDetectHandler(session as! TagType.ReaderSessionProtocol, tags)

--- a/Sources/NDEFTag/NFCNDEFTagReaderSessionProtocol.swift
+++ b/Sources/NDEFTag/NFCNDEFTagReaderSessionProtocol.swift
@@ -7,7 +7,7 @@
 
 public protocol NFCNDEFTagReaderSessionProtocol: NFCReaderSessionAfterBeginProtocol {
     #if canImport(CoreNFC)
-    func connect(to tag: NFCNDEFTag) async throws
+    func connect(to tag: any NFCNDEFTag) async throws
     #endif
 }
 

--- a/Tests/CoreTests/NFCReaderSessionableTests.swift
+++ b/Tests/CoreTests/NFCReaderSessionableTests.swift
@@ -16,7 +16,7 @@ final class NFCReaderSessionableTests: XCTestCase {
     func testNFCNDEFReaderSessionConformsToNFCReaderSessionable() throws {
         #if canImport(CoreNFC)
         XCTAssertIdentical(NFCNDEFReaderSession.Session.self, NFCNDEFReaderSession.self)
-        XCTAssertIdentical(NFCNDEFReaderSession.Delegate.self as AnyObject, NFCNDEFReaderSessionDelegate.self as AnyObject)
+        XCTAssertIdentical((any NFCNDEFReaderSession.Delegate).self as AnyObject, (any NFCNDEFReaderSessionDelegate).self as AnyObject)
         #else
         throw XCTSkip("Support for this platform is not considered.")
         #endif
@@ -34,7 +34,7 @@ final class NFCReaderSessionableTests: XCTestCase {
     func testNFCVASReaderSessionConformsToNFCReaderSessionable() throws {
         #if canImport(CoreNFC)
         XCTAssertIdentical(NFCVASReaderSession.Session.self, NFCVASReaderSession.self)
-        XCTAssertIdentical(NFCVASReaderSession.Delegate.self as AnyObject, NFCVASReaderSessionDelegate.self as AnyObject)
+        XCTAssertIdentical((any NFCVASReaderSession.Delegate).self as AnyObject, (any NFCVASReaderSessionDelegate).self as AnyObject)
         #else
         throw XCTSkip("Support for this platform is not considered.")
         #endif


### PR DESCRIPTION
- Swift 5.8 で存在型（existential types）を用いているところに `any` を付けていないときに、コンパイルエラーにする https://zenn.dev/treastrain/articles/555d4a2fc1b40b